### PR TITLE
Move WAIT_HOSTS to the docker-compose.yml file

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -146,6 +146,8 @@ services:
       - "awx_share:/share"
     ports:
       - "{{ awx_server_host }}:{{ awx_server_port }}:8052"
+    environment:
+      WAIT_HOSTS: memcached:11211, redis:6379, postgres:5432
     env_file:
       - "{{ manager_configuration_directory }}/awx.env"
     cap_add:

--- a/templates/env/awx.env.j2
+++ b/templates/env/awx.env.j2
@@ -14,5 +14,3 @@ AWX_ADMIN_USER={{ awx_username }}
 AWX_ADMIN_PASSWORD={{ awx_password }}
 AWX_SERVER_HOST={{ awx_server_host }}
 AWX_SERVER_PORT={{ awx_server_port }}
-
-WAIT_HOSTS=memcached:11211, redis:6379, postgres:5432


### PR DESCRIPTION
/etc/tower/conf.d/environment.sh: line 18: redis:6379,: command not found

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>