### PR TITLE
Fix 'comment not indented like content' warning in defaults/main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -149,10 +149,10 @@ vault_tag: latest
 vault_image: "{{ docker_registry_service }}/hashicorp/vault:{{ vault_tag }}"
 
 vault_config:
-# NOTE: during the TP the service runs in-memory
-#  backend:
-#    file:
-#      path: /vault/file
+  # NOTE: during the TP the service runs in-memory
+  #  backend:
+  #    file:
+  #      path: /vault/file
   default_lease_ttl: 168h
   max_lease_ttl: 720h
 vault_token: 00000000-0000-0000-0000-000000000000


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>