### PR TITLE
Remove /etc/tower/SECRET_KEY volume from AWX containers

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -94,7 +94,6 @@ services:
       - /etc/hosts:/etc/hosts:ro
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
-      - "{{ manager_configuration_directory }}/SECRET_KEY:/etc/tower/SECRET_KEY"
       - "{{ manager_configuration_directory }}/awx.env:/etc/tower/conf.d/environment.sh"
       - "{{ manager_configuration_directory }}/credentials.py:/etc/tower/conf.d/credentials.py"
       - "{{ manager_configuration_directory }}/nginx.conf:/etc/nginx/nginx.conf:ro"


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>