### PR TITLE
netbox: add more permissions to the ansible user (pt. 2)

### DIFF
--- a/templates/netbox/initializers/users.yml.j2
+++ b/templates/netbox/initializers/users.yml.j2
@@ -9,10 +9,18 @@
     - add_interface
     - add_ipaddress
     - change_device
+    - view_cluster
     - view_device
     - view_devicerole
     - view_devicetype
     - view_interface
     - view_ipaddress
+    - view_manufacturer
+    - view_platform
+    - view_rack
+    - view_region
+    - view_service
     - view_site
     - view_tag
+    - view_tenant
+    - view_virtualmachine


### PR DESCRIPTION
Required by netbox inventory plugin.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>