### PR TITLE
netbox: fix api tokens

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -125,10 +125,10 @@ netbox_secret_key: 00000000-0000-0000-0000-000000000000
 netbox_superuser_name: netbox
 netbox_superuser_email: netbox@osism.local
 netbox_superuser_password: password
-netbox_superuser_api_token: 00000000-0000-0000-0000-000000000000
+netbox_superuser_api_token: "0000000000000000000000000000000000000000"
 
 netbox_ansibleuser_name: ansible
-netbox_ansibleuser_api_token: 11111111-1111-1111-1111-111111111111
+netbox_ansibleuser_api_token: "1111111111111111111111111111111111111111"
 
 netbox_tag: latest
 netbox_image: "{{ docker_registry_service }}/netboxcommunity/netbox:{{ netbox_tag }}"


### PR DESCRIPTION
Ensure this value has at least 40 characters (it has 36)

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>